### PR TITLE
Mutex the workers, to behave more like native jest test runs

### DIFF
--- a/lib/createJestRunner.js
+++ b/lib/createJestRunner.js
@@ -25,7 +25,7 @@ const createRunner = runPath => {
       const mutex = throat(this._globalConfig.maxWorkers);
 
       const runTestInWorker = test =>
-        mutex(async () => {
+        mutex(() => {
           if (watcher.isInterrupted()) {
             throw new CancelRun();
           }

--- a/lib/createJestRunner.js
+++ b/lib/createJestRunner.js
@@ -24,7 +24,7 @@ const createRunner = runPath => {
 
       const mutex = throat(this._globalConfig.maxWorkers);
 
-      const runTestInWorker = test => {
+      const runTestInWorker = test =>
         mutex(async () => {
           if (watcher.isInterrupted()) {
             throw new CancelRun();


### PR DESCRIPTION
Makes the developer experience a bit nicer, and more like the `jest-runner` itself: https://github.com/facebook/jest/blob/e566a8f4106ac25b008744ffc42204554fd31cf6/packages/jest-runner/src/index.js#L104-L124

Here's an before/after using jest-runner-prettier on the jest repo itself using these settings:
```js
module.exports = {
  displayName: 'Prettier',
  runner: 'jest-runner-prettier',
  moduleFileExtensions: ['md'],
  testMatch: [
    '**/*.md',
  ],
};
```
Before:
![kapture 2018-03-20 at 22 43 54](https://user-images.githubusercontent.com/81981/37684832-9cd4231e-2c91-11e8-96f1-5e0391573bae.gif)

After:
![kapture 2018-03-20 at 22 46 03](https://user-images.githubusercontent.com/81981/37684849-a59c1bbe-2c91-11e8-9a3c-62e0b37a2db5.gif)

Love this library btw 🎉  Great stuff 😄 